### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build-linux-arm64-installer.yml
+++ b/.github/workflows/build-linux-arm64-installer.yml
@@ -45,7 +45,7 @@ jobs:
         python3 -m venv ../venv
         . ../venv/bin/activate
         pip3 install setuptools_scm
-        echo "ROSE_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> $GITHUB_OUTPUT
+        echo "ROSE_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> "$GITHUB_OUTPUT"
         deactivate
 
     - name: Test for secrets access
@@ -145,8 +145,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       id: tag-name
       run: |
-        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
-        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
+        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> "$GITHUB_OUTPUT"
+        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> "$GITHUB_OUTPUT"
 
     - name: Mark installer complete
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-linux-arm64-installer.yml
+++ b/.github/workflows/build-linux-arm64-installer.yml
@@ -45,7 +45,7 @@ jobs:
         python3 -m venv ../venv
         . ../venv/bin/activate
         pip3 install setuptools_scm
-        echo "::set-output name=ROSE_INSTALLER_VERSION::$(python3 ./build_scripts/installer-version.py)"
+        echo "ROSE_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> $GITHUB_OUTPUT
         deactivate
 
     - name: Test for secrets access
@@ -145,8 +145,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       id: tag-name
       run: |
-        echo "::set-output name=TAG_NAME::$(echo ${{ github.ref }} | cut -d'/' -f 3)"
-        echo "::set-output name=REPO_NAME::$(echo ${{ github.repository }} | cut -d'/' -f 2)"
+        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
+        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
 
     - name: Mark installer complete
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
     - name: Cache pip
       uses: actions/cache@v2.1.6
@@ -78,7 +78,7 @@ jobs:
         python3 -m venv ../venv
         . ../venv/bin/activate
         pip3 install setuptools_scm
-        echo "::set-output name=ROSE_INSTALLER_VERSION::$(python3 ./build_scripts/installer-version.py)"
+        echo "ROSE_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> $GITHUB_OUTPUT
         deactivate
 
     - name: Test for secrets access
@@ -165,8 +165,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       id: tag-name
       run: |
-        echo "::set-output name=TAG_NAME::$(echo ${{ github.ref }} | cut -d'/' -f 3)"
-        echo "::set-output name=REPO_NAME::$(echo ${{ github.repository }} | cut -d'/' -f 2)"
+        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
+        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
 
     - name: Mark installer complete
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+        echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
     - name: Cache pip
       uses: actions/cache@v2.1.6
@@ -78,7 +78,7 @@ jobs:
         python3 -m venv ../venv
         . ../venv/bin/activate
         pip3 install setuptools_scm
-        echo "ROSE_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> $GITHUB_OUTPUT
+        echo "ROSE_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> "$GITHUB_OUTPUT"
         deactivate
 
     - name: Test for secrets access
@@ -165,8 +165,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       id: tag-name
       run: |
-        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
-        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
+        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> "$GITHUB_OUTPUT"
+        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> "$GITHUB_OUTPUT"
 
     - name: Mark installer complete
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -46,7 +46,7 @@ jobs:
         python3 -m venv ../venv
         . ../venv/bin/activate
         pip3 install setuptools_scm
-        echo "ROSE_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> $GITHUB_OUTPUT
+        echo "ROSE_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> "$GITHUB_OUTPUT"
         deactivate
 
     - name: Test for secrets access
@@ -133,8 +133,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       id: tag-name
       run: |
-          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
-          echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
+          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> "$GITHUB_OUTPUT"
+          echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> "$GITHUB_OUTPUT"
 
     - name: Mark installer complete
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -46,7 +46,7 @@ jobs:
         python3 -m venv ../venv
         . ../venv/bin/activate
         pip3 install setuptools_scm
-        echo "::set-output name=ROSE_INSTALLER_VERSION::$(python3 ./build_scripts/installer-version.py)"
+        echo "ROSE_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> $GITHUB_OUTPUT
         deactivate
 
     - name: Test for secrets access
@@ -133,8 +133,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       id: tag-name
       run: |
-          echo "::set-output name=TAG_NAME::$(echo ${{ github.ref }} | cut -d'/' -f 3)"
-          echo "::set-output name=REPO_NAME::$(echo ${{ github.repository }} | cut -d'/' -f 2)"
+          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
+          echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
 
     - name: Mark installer complete
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
     - name: Cache pip
       uses: actions/cache@v2.1.6
@@ -112,7 +112,7 @@ jobs:
       id: version_number
       run: |
         . ./activate
-        echo "::set-output name=ROSE_INSTALLER_VERSION::$(rose version)"
+        echo "ROSE_INSTALLER_VERSION=$(rose version)" >> $GITHUB_OUTPUT
 
     - name: Upload MacOS artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+        echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
     - name: Cache pip
       uses: actions/cache@v2.1.6
@@ -112,7 +112,7 @@ jobs:
       id: version_number
       run: |
         . ./activate
-        echo "ROSE_INSTALLER_VERSION=$(rose version)" >> $GITHUB_OUTPUT
+        echo "ROSE_INSTALLER_VERSION=$(rose version)" >> "$GITHUB_OUTPUT"
 
     - name: Upload MacOS artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build-macos-m1-installer.yml
+++ b/.github/workflows/build-macos-m1-installer.yml
@@ -58,7 +58,7 @@ jobs:
           arch -arm64 python3 -m venv ../venv
           . ../venv/bin/activate
           arch -arm64 pip install setuptools_scm
-          echo "::set-output name=ROSE_INSTALLER_VERSION::$(arch -arm64 python3 ./build_scripts/installer-version.py)"
+          echo "ROSE_INSTALLER_VERSION=$(arch -arm64 python3 ./build_scripts/installer-version.py)" >> $GITHUB_OUTPUT
           deactivate
 
       # This will be recreated in the next step
@@ -149,8 +149,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         id: tag-name
         run: |
-          echo "::set-output name=TAG_NAME::$(echo ${{ github.ref }} | cut -d'/' -f 3)"
-          echo "::set-output name=REPO_NAME::$(echo ${{ github.repository }} | cut -d'/' -f 2)"
+          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
+          echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
 
       - name: Mark installer complete
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-macos-m1-installer.yml
+++ b/.github/workflows/build-macos-m1-installer.yml
@@ -58,7 +58,7 @@ jobs:
           arch -arm64 python3 -m venv ../venv
           . ../venv/bin/activate
           arch -arm64 pip install setuptools_scm
-          echo "ROSE_INSTALLER_VERSION=$(arch -arm64 python3 ./build_scripts/installer-version.py)" >> $GITHUB_OUTPUT
+          echo "ROSE_INSTALLER_VERSION=$(arch -arm64 python3 ./build_scripts/installer-version.py)" >> "$GITHUB_OUTPUT"
           deactivate
 
       # This will be recreated in the next step
@@ -149,8 +149,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         id: tag-name
         run: |
-          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
-          echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
+          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> "$GITHUB_OUTPUT"
+          echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> "$GITHUB_OUTPUT"
 
       - name: Mark installer complete
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Get npm cache directory
       id: npm-cache
       run: |
-        echo "::set-output name=dir::$(npm config get cache)"
+        echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
 
     - name: Cache npm
       uses: actions/cache@v2.1.6
@@ -45,7 +45,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
     - name: Cache pip
       uses: actions/cache@v2.1.6
@@ -69,7 +69,7 @@ jobs:
         unset HAS_AWS_SECRET
 
         if [ -n "$SIGNING_SECRET" ]; then HAS_SIGNING_SECRET='true' ; fi
-        echo "::set-output name=HAS_SIGNING_SECRET::${HAS_SIGNING_SECRET}"
+        echo "HAS_SIGNING_SECRET=${HAS_SIGNING_SECRET}" >> $GITHUB_OUTPUT
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
         echo ::set-output name=HAS_AWS_SECRET::${HAS_AWS_SECRET}
@@ -93,7 +93,7 @@ jobs:
         pip3 install setuptools_scm
         $env:ROSE_INSTALLER_VERSION = python .\build_scripts\installer-version.py -win
         echo "$env:ROSE_INSTALLER_VERSION"
-        echo "::set-output name=ROSE_INSTALLER_VERSION::$env:ROSE_INSTALLER_VERSION"
+        echo "ROSE_INSTALLER_VERSION=$env:ROSE_INSTALLER_VERSION" >> $GITHUB_OUTPUT
         deactivate
 
     - name: Build Windows installer with build_scripts\build_windows.ps1
@@ -172,8 +172,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       id: tag-name
       run: |
-        echo "::set-output name=TAG_NAME::$(echo ${{ github.ref }} | cut -d'/' -f 3)"
-        echo "::set-output name=REPO_NAME::$(echo ${{ github.repository }} | cut -d'/' -f 2)"
+        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
+        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
 
     - name: Mark installer complete
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Get npm cache directory
       id: npm-cache
       run: |
-        echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+        echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
 
     - name: Cache npm
       uses: actions/cache@v2.1.6
@@ -45,7 +45,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+        echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
     - name: Cache pip
       uses: actions/cache@v2.1.6
@@ -69,7 +69,7 @@ jobs:
         unset HAS_AWS_SECRET
 
         if [ -n "$SIGNING_SECRET" ]; then HAS_SIGNING_SECRET='true' ; fi
-        echo "HAS_SIGNING_SECRET=${HAS_SIGNING_SECRET}" >> $GITHUB_OUTPUT
+        echo "HAS_SIGNING_SECRET=${HAS_SIGNING_SECRET}" >> "$GITHUB_OUTPUT"
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
         echo ::set-output name=HAS_AWS_SECRET::${HAS_AWS_SECRET}
@@ -93,7 +93,7 @@ jobs:
         pip3 install setuptools_scm
         $env:ROSE_INSTALLER_VERSION = python .\build_scripts\installer-version.py -win
         echo "$env:ROSE_INSTALLER_VERSION"
-        echo "ROSE_INSTALLER_VERSION=$env:ROSE_INSTALLER_VERSION" >> $GITHUB_OUTPUT
+        echo "ROSE_INSTALLER_VERSION=$env:ROSE_INSTALLER_VERSION" >> "$GITHUB_OUTPUT"
         deactivate
 
     - name: Build Windows installer with build_scripts\build_windows.ps1
@@ -172,8 +172,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       id: tag-name
       run: |
-        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
-        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
+        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> "$GITHUB_OUTPUT"
+        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> "$GITHUB_OUTPUT"
 
     - name: Mark installer complete
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -15,8 +15,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         id: tag-name
         run: |
-          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
-          echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
+          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> "$GITHUB_OUTPUT"
+          echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> "$GITHUB_OUTPUT"
       - name: Start release
         if: startsWith(github.ref, 'refs/tags/')
         run: |

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -15,8 +15,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         id: tag-name
         run: |
-          echo "::set-output name=TAG_NAME::$(echo ${{ github.ref }} | cut -d'/' -f 3)"
-          echo "::set-output name=REPO_NAME::$(echo ${{ github.repository }} | cut -d'/' -f 2)"
+          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
+          echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
       - name: Start release
         if: startsWith(github.ref, 'refs/tags/')
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


